### PR TITLE
specify location for padloc db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ data/
 Dockerfile
 results/
 .cache/
+resources/padloc_db/

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -5,3 +5,7 @@ samples: "config/samples.tsv"
 
 # glob to find assembly names
 assembly_glob: "data/protein_sequences/{assembly}.faa"
+
+# directory into which the padloc database will be downloaded
+padloc_db_dir: resources/padloc_db
+

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -13,12 +13,12 @@ validate(config, schema="../schemas/config.schema.yaml")
 
 samples = pd.read_csv(config["samples"], sep="\t")
 SAMPLE_NAMES = samples["sample"]
+PADLOC_DB_DIR = config["padloc_db_dir"]
 validate(samples, schema="../schemas/samples.schema.yaml")
 
 
 ################ define helper functions
 import pandas as pd
-import hashlib
 import os
 import glob
 import gzip, shutil
@@ -36,26 +36,6 @@ def download_seq_files(gcf):
     # download gff and faa files
     wget.download(gff, out = "data/annotation/" + gcf + ".gff.gz")
     wget.download(faa, out = "data/protein_seq/" + gcf + ".faa.gz")
-
-## find conda environment hash, adapted from
-## https://bioinformatics.stackexchange.com/a/9346
-def find_conda_env_hash(yaml):
-
-    # if this workflow is used as a module, the padloc yaml file is not available locally
-    # therefore download the file
-    if not os.path.isfile(yaml):
-        wget.download(
-            "https://github.com/ezherman/find-defence-systems/blob/master/workflow/envs/padloc.yaml",
-            out = yaml
-            )
-
-    md5hash = hashlib.md5()
-    md5hash.update((os.getcwd() + "/.snakemake/conda").encode())
-    f = open(yaml, 'rb')
-    md5hash.update(f.read())
-    f.close()
-    h = md5hash.hexdigest()
-    return h
 
 ## wrangle pandas dataframe for padloc and defense_finder
 def create_subsystem_table(df, program):

--- a/workflow/rules/run_padloc.smk
+++ b/workflow/rules/run_padloc.smk
@@ -6,10 +6,11 @@ rule run_padloc:
     input:
         faa = "data/protein_seq/{sample}.faa",
         gff = "data/annotation/{sample}.gff",
-        hmm = ".snakemake/conda/" + find_conda_env_hash("workflow/envs/padloc.yaml") + "/data/hmm"
+        hmm = PADLOC_DB_DIR + "/hmm"
     conda: "../envs/padloc.yaml"
+    params: pdd = PADLOC_DB_DIR
     shell:
         r"""touch {output.csv} #empty output file in case padloc finds no results
                                #otherwise snakemake exits due to lack of output file
-            padloc --force --faa {input.faa} --gff {input.gff} --outdir {output.dir}
+            padloc --force --data {params.pdd} --faa {input.faa} --gff {input.gff} --outdir {output.dir}
          """

--- a/workflow/rules/update_padloc_db.smk
+++ b/workflow/rules/update_padloc_db.smk
@@ -3,7 +3,8 @@
 # padloc env directory that Snakemake creates includes a hash key that is
 # dependent on the user's machine
 rule update_padloc_db:
-    output: directory(".snakemake/conda/" + find_conda_env_hash("workflow/envs/padloc.yaml") + "/data/hmm")
+    output: directory(PADLOC_DB_DIR + "/hmm")
     conda: "../envs/padloc.yaml"
+    params: pdd = PADLOC_DB_DIR
     shell:
-        "padloc --db-update"
+        "padloc --data {params.pdd} --db-update"


### PR DESCRIPTION
Padloc DB is downloaded into `resources/padloc_db` rather than the padloc conda environment. This removes the need to figure out the conda environment directory hash generated by snakemake. 