### PR TITLE
fix: defense finder file naming

### DIFF
--- a/workflow/rules/run_defense_finder.smk
+++ b/workflow/rules/run_defense_finder.smk
@@ -15,5 +15,5 @@ rule run_defense_finder:
             rm -rf $outdir #if the outdir exists, remove it
             gunzip -c {input.data} > {output.faa}
             defense-finder run {output.faa} --out-dir $outdir -w {threads}
-            rename "{wildcards.sample}_" "" $outdir/* #defense finder includes sample in the filenames
+            rename "{wildcards.sample}_" "" $outdir/* #defense finder update introduced sample in the filenames
          """


### PR DESCRIPTION
Update of defense finder or macsyfinder seems to be returning the name of the fasta file (`{wildcards.sample}`) as a prefix to output files. This PR renames the output files, to avoid changing filenames in this and downstream workflows